### PR TITLE
fix: avoid hang on Flutter Windows standalone with native-assets

### DIFF
--- a/FORK_README.md
+++ b/FORK_README.md
@@ -1,0 +1,65 @@
+# fllama (fork)
+
+> This is a fork of [Telosnex/fllama](https://github.com/Telosnex/fllama)
+> with a specific fix for Flutter **Windows standalone** builds.
+> All credit goes to the original authors. The upstream `README.md`
+> and `LICENSE` are preserved unchanged.
+
+## Why this fork exists
+
+On Flutter Windows **standalone** builds (a built `.exe`, not `flutter
+run`) with **native-assets** enabled, fllama hangs silently during the
+helper-isolate setup: `await Isolate.spawn(...)` in
+`_helperIsolateSendPort` never returns, even though the child isolate
+runs correctly and the `SendPort` handshake actually completes.
+
+The `Future<Isolate>` returned by `Isolate.spawn()` never resolves on
+this configuration (the VM-level "isolate started" ACK is not
+delivered back to the spawner). The `Completer` populated by the
+child's `SendPort` handshake is the real synchronization mechanism, so
+awaiting the spawn `Future` is unnecessary.
+
+## What's different from upstream
+
+Branch **`fix/windows-isolate-spawn-hang`**, a single commit on top of
+upstream `db62c20`:
+
+- `lib/io/fllama_io_inference.dart`: `await Isolate.spawn(...)` →
+  `unawaited(Isolate.spawn(...))`
+
+The commit message contains the full diagnosis methodology (cdb dump
++ 5-marker instrumentation discriminating the spawn flow).
+
+## How to use this fork
+
+In your `pubspec.yaml`:
+
+```yaml
+fllama:
+  git:
+    url: https://github.com/<your-username>/fllama.git
+    ref: fix/windows-isolate-spawn-hang
+```
+
+(Replace `<your-username>` with the actual fork URL once pushed.)
+
+## Known limitation
+
+This fix addresses the **handshake-level** hang only. A separate
+**downstream** blocker remains in the inference path on this same
+configuration (a hang, not a crash, after the handshake completes).
+It is unrelated to this fix and is still under investigation.
+
+## Upstream status
+
+A pull request proposing this fix will be opened against
+[Telosnex/fllama](https://github.com/Telosnex/fllama). Once merged
+upstream, this fork becomes obsolete — switch back to the original
+repository.
+
+## License
+
+Same as upstream: **GPL v2** (a commercial license is also available
+from Telosnex Inc. — see `LICENSE`). Any modifications in this fork
+are likewise released under **GPL v2**, in compliance with the
+original license. The original `LICENSE` file is preserved unchanged.

--- a/lib/io/fllama_io_inference.dart
+++ b/lib/io/fllama_io_inference.dart
@@ -198,7 +198,17 @@ Future<SendPort> _helperIsolateSendPort = () async {
     });
 
   // Start the helper isolate.
-  await Isolate.spawn(_fllamaInferenceIsolate, receivePort.sendPort);
+  //
+  // Fix: avoid hang on Flutter Windows standalone with native-assets.
+  //
+  // The Future<Isolate> returned by Isolate.spawn() never resolves on this
+  // configuration (the VM-level "isolate started" ACK is not delivered back
+  // to the spawner), even though the child isolate runs correctly and the
+  // SendPort handshake succeeds. Awaiting that Future therefore hangs
+  // forever. The Completer populated by the child's SendPort handshake is
+  // the real synchronization mechanism, so we don't need to await the
+  // spawn — unawaited() makes the intentional fire-and-forget explicit.
+  unawaited(Isolate.spawn(_fllamaInferenceIsolate, receivePort.sendPort));
 
   // Wait until the helper isolate has sent us back the SendPort on which we
   // can start sending requests.


### PR DESCRIPTION
## Summary

`await Isolate.spawn()` in `_helperIsolateSendPort` (in 
`lib/io/fllama_io_inference.dart`) never completes on Flutter Windows 
standalone builds with native-assets. The child isolate itself runs 
correctly and the SendPort handshake succeeds, but the `Future<Isolate>` 
returned by `Isolate.spawn()` never resolves, causing a silent hang 
in `fllamaInference()`.

This appears to be a Dart SDK / native-assets interaction issue where 
the VM-level ACK for `Isolate.spawn` is not delivered back to the 
spawner on Flutter Windows standalone builds. The application-level 
handshake (via `Completer` + `SendPort`) works correctly.

## Diagnosis

Investigation methodology used to identify the root cause:

1. **cdb memory dump** captured on the hung process showed 
   `fllama.dll` was never loaded (`lmv m fllama` returned empty), 
   with all 54 threads parked at idle (`!runaway` ≈ 0% CPU). 
   This proved the hang was upstream of any native code execution.

2. **Five markers** were instrumented across the spawn flow in 
   `_helperIsolateSendPort`:
   - M1: just before `await Isolate.spawn(...)`
   - M2: just after `await Isolate.spawn(...)` (next line)
   - M3: first instruction of `_fllamaInferenceIsolate` (child)
   - M4: just before `sendPort.send(helperReceivePort.sendPort)` (child)
   - M5: first instruction of `receivePort.listen` (main)

3. **First run** showed: M1, M3, M4, M5 all present (handshake 
   completed in ~15 ms), but **M2 absent** — proving the line after 
   `await Isolate.spawn()` is never reached, even though the child 
   isolate runs fully and the Completer is populated.

4. **Second run with `unawaited()`** showed: all 5 markers present, 
   handshake completes correctly, application proceeds past the 
   spawn.

## Fix

Replace `await Isolate.spawn(...)` with `unawaited(Isolate.spawn(...))`.

Since the `Completer` (populated by the child's SendPort handshake) 
is the real synchronization mechanism, we don't need to await the 
spawn Future itself. `unawaited()` makes this explicit and avoids 
the hang on the never-resolving Future.

## Testing

Reproduced and verified on:
- **Hardware**: Intel Arrow Lake-H (Core Ultra 9 285H)
- **Flutter**: 3.41.9
- **fllama**: db62c20 (also reproduces on a8f3087)
- **Build modes**: both `--debug` and `--release` reproduce the hang 
  without the fix, both progress past the handshake with the fix

## Note

A downstream blocker remains in the inference path after the handshake 
completes — the application reaches the inference call but no tokens 
are produced (timeout, no native logs). This is a **separate issue** 
to investigate independently and is not addressed by this PR.

## License

This contribution is offered under the same GPL v2 license as the 
upstream project.